### PR TITLE
feat: add createOrder helper

### DIFF
--- a/createOrder.js
+++ b/createOrder.js
@@ -1,0 +1,46 @@
+const http = require('http');
+
+/**
+ * Create an order using the provided shipping information.
+ * @param {string} fullName - Customer's full name.
+ * @param {string} shippingAddress - Shipping address.
+ * @returns {Promise<object>} Resolves with the parsed JSON response.
+ */
+function createOrder(fullName, shippingAddress) {
+  return new Promise((resolve, reject) => {
+    const data = JSON.stringify({ fullName, shippingAddress });
+
+    const req = http.request(
+      'http://localhost:5002/api/v1/order/create-order',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(data),
+        },
+      },
+      (res) => {
+        let body = '';
+        res.on('data', (chunk) => (body += chunk));
+        res.on('end', () => {
+          if (res.statusCode >= 200 && res.statusCode < 300) {
+            try {
+              resolve(JSON.parse(body));
+            } catch (e) {
+              resolve(body);
+            }
+          } else {
+            reject(new Error(`Request failed with status ${res.statusCode}: ${body}`));
+          }
+        });
+      }
+    );
+
+    req.on('error', reject);
+    req.write(data);
+    req.end();
+  });
+}
+
+module.exports = createOrder;
+


### PR DESCRIPTION
## Summary
- add helper function to create order via backend API

## Testing
- `node -e "const fn=require('./createOrder'); console.log('type', typeof fn)"`


------
https://chatgpt.com/codex/tasks/task_e_6895a367746483329adacc7e22e2decb